### PR TITLE
Support streaming response bodies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ update-version:
 endpoints:
 	dune exec endpoint-gen -- -i input/endpoints.json -o lib
 
-LIBRARIES := $(shell for file in `find ./input/ -maxdepth 1 -type d \! -name input -exec basename {} \;`; do echo "aws-$$file"; done)
+LIBRARIES := $(shell \
+  FILES=$$(find ./input/ -maxdepth 1 -type d \! -name input -exec basename {} \;); \
+  for file in $$FILES; \
+    do echo "aws-$$file"; \
+  done)
 
 .PHONY: $(LIBRARIES)
 $(LIBRARIES): aws-%:

--- a/lib/aws.mli
+++ b/lib/aws.mli
@@ -121,6 +121,8 @@ module type Call = sig
       for a single API. *)
   type error
 
+  val streaming : bool
+
   (** The AWS service, for example, 'ec2'. This is used for request
       signing, and to determine the endpoint to send the request. *)
   val service : string
@@ -133,7 +135,12 @@ module type Call = sig
 
   (** This function converts from a HTTP response body to an output
       or an error if the response could not be decoded. *)
-  val of_http : (string * string) list -> string -> [`Ok of output | `Error of error Error.error_response]
+  val of_http
+    :  (string * string) list
+    -> [ `String of string | `Streaming of Piaf.Body.t ]
+    -> [ `Ok of output
+       | `Error of error Error.error_response
+       ]
 
   (** This function parses an AWS error (which has been successfully
       deserialized from XML) into an API specific native error that

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name aws)
  (public_name aws)
- (libraries uri calendar ezxmlm digestif.c))
+ (libraries piaf uri calendar ezxmlm digestif.c))

--- a/lwt/runtime.mli
+++ b/lwt/runtime.mli
@@ -46,6 +46,8 @@ val run_request :
   ('input, 'output, 'error) Aws.call ->
   'input -> ('output, 'error Aws.Error.t) result Lwt.t
 
+val shutdown : t -> unit Lwt.t
+
 module Oneshot : sig
   val run_request :
     region:string ->

--- a/src/reading.ml
+++ b/src/reading.ml
@@ -48,7 +48,14 @@ module Json = struct
 end
 
 let unreserve =
-  let reserved_words = [("and", "and_");("type", "type_");("to", "to_");("end", "end_")] in
+  let reserved_words =
+    [ "and", "and_"
+    ; "type", "type_"
+    ; "to", "to_"
+    ; "end", "end_"
+    ; "include", "include_"
+    ]
+  in
   fun s -> try List.assoc s reserved_words with Not_found -> s
 
 let parse_member rq payload (mnm, mj) =

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -90,6 +90,10 @@ let styvariantlet nm variants =
                       (List.map (fun (cnm,args) -> Type.constructor ~args:(Pcstr_tuple args) (strloc cnm)) variants))
        (strloc nm)]
 
+(* type nm = nm0 * nm1 *)
+let tytup _nm elts =
+ Typ.tuple elts
+
 (* fun ~arg -> body *)
 let funlab arg body =
   Exp.fun_ (Labelled arg) None (Pat.var (strloc arg)) body


### PR DESCRIPTION
This is useful for S3 responses which may be large files that we don't
want to fully buffer in memory.

A shortcoming of this is that it makes the core lib depend on Piaf,
which is a problem to solve at a later date.